### PR TITLE
tracks/invoice line items per invoice

### DIFF
--- a/invoice_37_line_item_count.sql
+++ b/invoice_37_line_item_count.sql
@@ -1,0 +1,4 @@
+SELECT
+    COUNT(*)
+FROM InvoiceLine
+WHERE InvoiceId = 37;

--- a/line-items-per-invoice.sql
+++ b/line-items-per-invoice.sql
@@ -1,0 +1,7 @@
+SELECT
+    DISTINCT il.InvoiceId,
+    COUNT(*) AS Tracks
+FROM InvoiceLine as il
+JOIN Invoice as i
+WHERE i.InvoiceId = il.InvoiceId
+GROUP BY il.InvoiceId


### PR DESCRIPTION
## Returns a queryset of the number of invoice lines per invoice.

Seeing as this is a music store, each invoice line is the track, $/unit, and total units sold.